### PR TITLE
Add script/release for rubygems release

### DIFF
--- a/script/release
+++ b/script/release
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Tag and push a release.
+
+set -e
+set -x
+
+# Make sure we're in the project root.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+cd ${DIR}
+
+# Build a new gem archive.
+
+rm -rf entitlements-gitrepo-auditor-plugin-*.gem
+gem build -q entitlements-gitrepo-auditor-plugin.gemspec
+
+# Make sure we're on the main branch.
+
+(git branch --no-color | grep -q '* main') || {
+  echo "Only release from the main branch."
+  exit 1
+}
+
+# Figure out what version we're releasing.
+
+tag=v`ls entitlements-gitrepo-auditor-plugin-*.gem | sed 's/^entitlements-gitrepo-auditor-plugin-\(.*\)\.gem$/\1/'`
+
+# Make sure we haven't released this version before.
+
+git fetch -t origin
+
+(git tag -l | grep -q "$tag") && {
+  echo "Whoops, there's already a '${tag}' tag."
+  exit 1
+}
+
+# Tag it and bag it.
+
+gem push entitlements-gitrepo-auditor-plugin-*.gem && git tag "$tag" &&
+  git push origin main && git push origin "$tag"


### PR DESCRIPTION
![DALL·E 2022-08-15 16 30 19 - futuristic neon lit sasquatch singing _let it go_ from frozen](https://user-images.githubusercontent.com/6259/184722032-36b806c7-6c83-4ded-84df-eb4a5b87a4d5.png)

_(dall-e 2: "futuristic neon lit sasquatch singing "let it go" from frozen")_

We want to have the tooling in place to do rubygems releases, and, well, do a release.

**the work**

 - [x] bring in `script/release`
 - [ ] merge
 - [ ] push gem

References: 
 - https://github.com/github/entitlements-app/pull/10
 - https://github.com/github/entitlements-app/pull/9
 - https://github.com/github/entitlements-github-plugin/pull/7

cc @DanHoerst @github/entitlements-reviewers 